### PR TITLE
修复FOFA插件无返回结果的BUG

### DIFF
--- a/lib/api/fofa/pack.py
+++ b/lib/api/fofa/pack.py
@@ -55,7 +55,7 @@ def FofaSearch(query, limit=100, offset=0):  # TODO 付费获取结果的功能�
         response = urllib.urlopen(request)
         resp = response.readlines()[0]
         resp = json.loads(resp)
-        if resp["error"] is None:
+        if not resp["error"]:
             for item in resp.get('results'):
                 result.append(item[0])
             if resp.get('size') >= 100:


### PR DESCRIPTION
BUG说明：
resp中包含"error"键，值为True或False，如果执行`if resp["error"] is None:`进行判断的话，当error未False，即理应成功返回扫描结果时，判断会为"False"，跳过执行这段if，直接终止了结果的返回。
修复方法：
改为`if not resp["error"]:`，进行error键的真假值判断，若error键的值为False，则if判断为真，执行扫描结果的返回操作。